### PR TITLE
Fix GitHub Actions version pin

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -16,6 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: chartboost/ruff-action@v1
+      - uses: chartboost/ruff-action@v1.0.0
         with:
           args: check . --output-format=github


### PR DESCRIPTION
## Summary
- GitHub Actions の `chartboost/ruff-action` を `v1` から `v1.0.0` に固定

## Testing
- `ruff check . --output-format=github`